### PR TITLE
Fix ECO crafting CPU tick budget and JDK 21 build setup

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,64 @@
+# Building Neo ECO AE Extension
+
+Use **JDK 21** to run the Gradle wrapper for this Minecraft 1.21.1 / NeoForge 1.21.1 project.
+
+## Required toolchain
+
+- **Gradle wrapper:** 8.12.1
+- **Gradle runtime JDK:** 21
+- **Java toolchain target:** 21
+
+The project now fails fast when Gradle 8.12.1 is launched on Java 25+.
+
+## Command line
+
+### Windows PowerShell
+
+Use the helper for the current shell:
+
+```powershell
+. .\scripts\use-jdk21.ps1
+.\gradlew.bat --version
+.\gradlew.bat compileJava --no-daemon
+.\gradlew.bat jar --no-daemon
+```
+
+To update your user environment permanently:
+
+```powershell
+setx JAVA_HOME "C:\Program Files\Java\jdk-21"
+setx PATH "%JAVA_HOME%\bin;%PATH%"
+```
+
+### Linux / macOS
+
+Use the helper for the current shell:
+
+```bash
+source ./scripts/use-jdk21.sh
+./gradlew --version
+./gradlew compileJava --no-daemon
+./gradlew jar --no-daemon
+```
+
+To update your current shell manually:
+
+```bash
+export JAVA_HOME=/path/to/jdk-21
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+## IDE setup
+
+Set the **Gradle JVM** and **Project SDK** to **JDK 21**.
+
+- IntelliJ IDEA: `Settings | Build, Execution, Deployment | Build Tools | Gradle | Gradle JVM`
+- Also set `Project Structure | SDK` to JDK 21
+
+`runClient`, `runServer`, and other Gradle run configurations should use the same JDK 21 Gradle JVM.
+
+## Known build limitation
+
+`compileJava` and `jar` work on JDK 21 in the current repository state.
+
+The `:test` task currently fails during task instantiation with a pre-existing Gradle reporting issue (`DefaultTestTaskReports` / `DefaultReportContainer`, `Type T not present`). That problem is not part of the ECO crafting watchdog fix and was left unchanged.

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,13 @@ plugins {
     id 'io.freefair.lombok' version '8.7.1'
 }
 
+def gradleLauncherJava = JavaVersion.current().majorVersion.toInteger()
+if (gradle.gradleVersion == '8.12.1' && gradleLauncherJava >= 25) {
+    throw new GradleException(
+        'Unsupported Java runtime for this project. Use JDK 21 to run Gradle 8.12.1 for Neo ECO AE Extension / Minecraft 1.21.1.'
+    )
+}
+
 tasks.named('wrapper', Wrapper).configure {
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/scripts/use-jdk21.ps1
+++ b/scripts/use-jdk21.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$JdkHome
+)
+
+$candidates = @()
+if ($JdkHome) { $candidates += $JdkHome }
+if ($env:JAVA_HOME_21_X64) { $candidates += $env:JAVA_HOME_21_X64 }
+
+$roots = @(
+    'C:\Program Files\Microsoft',
+    'C:\Program Files\Eclipse Adoptium',
+    'C:\Program Files\Zulu',
+    'C:\Program Files\Java'
+)
+
+foreach ($root in $roots) {
+    if (Test-Path $root) {
+        $candidates += Get-ChildItem $root -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '(^|[-_])21([._-]|$)|jdk-21|zulu-21' } |
+            Sort-Object FullName -Descending |
+            Select-Object -ExpandProperty FullName
+    }
+}
+
+$resolved = $candidates |
+    Where-Object { $_ -and (Test-Path (Join-Path $_ 'bin\java.exe')) } |
+    Select-Object -First 1
+
+if (-not $resolved) {
+    Write-Error 'Unable to locate a JDK 21 installation. Pass -JdkHome or set JAVA_HOME_21_X64.'
+    return
+}
+
+$env:JAVA_HOME = $resolved
+$env:Path = "$resolved\bin;$env:Path"
+
+Write-Host "JAVA_HOME set to $env:JAVA_HOME"
+& java -version
+Write-Host ''
+Write-Host 'This script updates the current shell only. Dot-source it with:'
+Write-Host '. .\scripts\use-jdk21.ps1'

--- a/scripts/use-jdk21.sh
+++ b/scripts/use-jdk21.sh
@@ -7,7 +7,14 @@ fi
 
 resolve_candidate() {
   local candidate="$1"
-  [[ -n "$candidate" && -x "$candidate/bin/java" ]] && printf '%s\n' "$candidate"
+  if [[ -n "$candidate" && -x "$candidate/bin/java" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [[ -n "$candidate" && -x "$candidate/Contents/Home/bin/java" ]]; then
+    printf '%s\n' "$candidate/Contents/Home"
+    return 0
+  fi
 }
 
 if [[ $# -gt 0 ]]; then
@@ -26,7 +33,17 @@ if [[ -z "${resolved:-}" ]]; then
     while IFS= read -r candidate; do
       resolved="$(resolve_candidate "$candidate" || true)"
       [[ -n "$resolved" ]] && break 2
-    done < <(find "$root" -maxdepth 1 -type d \( -name '*21*' -o -name 'jdk-21*' \) 2>/dev/null | sort -r)
+    done < <(find "$root" -maxdepth 1 -type d \
+      \( -name 'jdk-21*' \
+         -o -name 'java-21*' \
+         -o -name '*openjdk-21*' \
+         -o -name '*temurin-21*' \
+         -o -name '*zulu-21*' \
+         -o -name '*microsoft-21*' \
+         -o -name '*corretto-21*' \
+         -o -name '*-21*.jdk' \
+         -o -name 'jdk-21*.jdk' \) \
+      2>/dev/null | sort -r)
   done
 fi
 

--- a/scripts/use-jdk21.sh
+++ b/scripts/use-jdk21.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Source this script to update the current shell: source ./scripts/use-jdk21.sh" >&2
+fi
+
+resolve_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -x "$candidate/bin/java" ]] && printf '%s\n' "$candidate"
+}
+
+if [[ $# -gt 0 ]]; then
+  resolved="$(resolve_candidate "$1" || true)"
+else
+  resolved=""
+fi
+
+if [[ -z "${resolved:-}" && -n "${JAVA_HOME_21_X64:-}" ]]; then
+  resolved="$(resolve_candidate "$JAVA_HOME_21_X64" || true)"
+fi
+
+if [[ -z "${resolved:-}" ]]; then
+  for root in /usr/lib/jvm /Library/Java/JavaVirtualMachines "${HOME}/.jdks"; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r candidate; do
+      resolved="$(resolve_candidate "$candidate" || true)"
+      [[ -n "$resolved" ]] && break 2
+    done < <(find "$root" -maxdepth 1 -type d \( -name '*21*' -o -name 'jdk-21*' \) 2>/dev/null | sort -r)
+  done
+fi
+
+if [[ -z "${resolved:-}" ]]; then
+  echo "Unable to locate a JDK 21 installation. Pass the path as the first argument or set JAVA_HOME_21_X64." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+export JAVA_HOME="$resolved"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+echo "JAVA_HOME set to $JAVA_HOME"
+java -version

--- a/src/main/java/cn/dancingsnow/neoecoae/api/me/ECOCraftingCPULogic.java
+++ b/src/main/java/cn/dancingsnow/neoecoae/api/me/ECOCraftingCPULogic.java
@@ -1,14 +1,18 @@
 package cn.dancingsnow.neoecoae.api.me;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
 import com.google.common.base.Preconditions;
 
+import cn.dancingsnow.neoecoae.config.NEConfig;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -17,6 +21,7 @@ import net.minecraft.world.level.Level;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
+import appeng.api.crafting.IPatternDetails;
 import appeng.api.features.IPlayerRegistry;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingLink;
@@ -38,6 +43,11 @@ import appeng.hooks.ticking.TickHandler;
 import appeng.me.service.CraftingService;
 
 public class ECOCraftingCPULogic {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ECOCraftingCPULogic.class);
+    private static final double POWER_EPSILON = 0.01;
+    private static final int LOW_POWER_BACKOFF_TICKS = 2;
+    private static final int BUDGET_WARNING_THRESHOLD = 20;
+    private static final long BUDGET_WARNING_INTERVAL_TICKS = 200;
 
     final ECOCraftingCPU cpu;
 
@@ -63,6 +73,8 @@ public class ECOCraftingCPULogic {
 
     @Getter
     private boolean markedForDeletion = false;
+    private long lastBudgetWarningTick = Long.MIN_VALUE;
+    private int consecutiveBudgetExhaustions = 0;
 
     public ECOCraftingCPULogic(ECOCraftingCPU cpu) {
         this.cpu = cpu;
@@ -140,19 +152,14 @@ public class ECOCraftingCPULogic {
             return;
         }
 
-        var remainingOperations = cpu.getCoProcessors() + 1;
-
-        if (remainingOperations > 0) {
-            do {
-                var pushedPatterns = executeCrafting(remainingOperations, cc, eg, cpu.getLevel());
-
-                if (pushedPatterns > 0) {
-                    remainingOperations -= pushedPatterns;
-                } else {
-                    break;
-                }
-            } while (remainingOperations > 0);
+        var currentTick = TickHandler.instance().getCurrentTick();
+        if (job.lowPowerUntilTick > currentTick) {
+            return;
         }
+
+        var budget = createTickBudget();
+        var result = executeCrafting(budget, cc, eg, cpu.getLevel(), currentTick);
+        handleTickResult(result, budget, currentTick);
     }
 
     /**
@@ -160,85 +167,46 @@ public class ECOCraftingCPULogic {
      *
      * @return How many patterns were successfully pushed.
      */
-    public int executeCrafting(
-        int maxPatterns, CraftingService craftingService, IEnergyService energyService, Level level) {
+    private CraftingTickResult executeCrafting(
+        CraftingTickBudget budget, CraftingService craftingService, IEnergyService energyService, Level level, long currentTick) {
         var job = this.job;
-        if (job == null) return 0;
-
-        var pushedPatterns = 0;
-
-        var it = job.tasks.entrySet().iterator();
-        taskLoop:
-        while (it.hasNext()) {
-            var task = it.next();
-            if (task.getValue().value <= 0) {
-                it.remove();
-                continue;
-            }
-
-            var details = task.getKey();
-            var expectedOutputs = new KeyCounter();
-            var expectedContainerItems = new KeyCounter();
-            // Contains the inputs for the pattern.
-            @Nullable
-            var craftingContainer = CraftingCpuHelper.extractPatternInputs(
-                details, inventory, level, expectedOutputs, expectedContainerItems);
-
-            // Try to push to each provider.
-            for (var provider : craftingService.getProviders(details)) {
-                if (craftingContainer == null) break;
-                if (provider.isBusy()) continue;
-
-                var patternPower = CraftingCpuHelper.calculatePatternPower(craftingContainer);
-
-                if (energyService.extractAEPower(patternPower, Actionable.SIMULATE, PowerMultiplier.CONFIG)
-                    < patternPower - 0.01) break;
-
-                if (provider.pushPattern(details, craftingContainer)) {
-                    energyService.extractAEPower(patternPower, Actionable.MODULATE, PowerMultiplier.CONFIG);
-                    pushedPatterns++;
-
-                    for (var expectedOutput : expectedOutputs) {
-                        job.waitingFor.insert(
-                            expectedOutput.getKey(), expectedOutput.getLongValue(), Actionable.MODULATE);
-                    }
-                    for (var expectedContainerItem : expectedContainerItems) {
-                        job.waitingFor.insert(
-                            expectedContainerItem.getKey(),
-                            expectedContainerItem.getLongValue(),
-                            Actionable.MODULATE);
-                        job.timeTracker.addMaxItems(
-                            expectedContainerItem.getLongValue(),
-                            expectedContainerItem.getKey().getType());
-                    }
-
-                    cpu.markDirty();
-
-                    task.getValue().value--;
-                    if (task.getValue().value <= 0) {
-                        it.remove();
-                        continue taskLoop;
-                    }
-
-                    if (pushedPatterns == maxPatterns) {
-                        break taskLoop;
-                    }
-
-                    // Prepare next inputs.
-                    expectedOutputs.reset();
-                    expectedContainerItems.reset();
-                    craftingContainer = CraftingCpuHelper.extractPatternInputs(
-                        details, inventory, level, expectedOutputs, expectedContainerItems);
-                }
-            }
-
-            // Failed to push this pattern, reinject the inputs.
-            if (craftingContainer != null) {
-                CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
-            }
+        if (job == null) return new CraftingTickResult(0, ExhaustionReason.NONE);
+        if (job.tasks.isEmpty()) {
+            job.nextTaskIndex = 0;
+            return new CraftingTickResult(0, ExhaustionReason.NONE);
         }
 
-        return pushedPatterns;
+        var initialTaskCount = job.tasks.size();
+        var startTaskIndex = normalizeIndex(job.nextTaskIndex, initialTaskCount);
+        var result = processTaskRange(
+            job,
+            startTaskIndex,
+            initialTaskCount,
+            budget,
+            craftingService,
+            energyService,
+            level,
+            currentTick);
+
+        if (result.exhaustionReason == ExhaustionReason.NONE && startTaskIndex > 0 && budget.canContinue()) {
+            var wrappedResult = processTaskRange(
+                job,
+                0,
+                Math.min(startTaskIndex, job.tasks.size()),
+                budget,
+                craftingService,
+                energyService,
+                level,
+                currentTick);
+            result = result.merge(wrappedResult);
+        }
+
+        if (job.tasks.isEmpty()) {
+            job.nextTaskIndex = 0;
+        } else {
+            job.nextTaskIndex = normalizeIndex(job.nextTaskIndex, job.tasks.size());
+        }
+        return result;
     }
 
     /**
@@ -507,5 +475,397 @@ public class ECOCraftingCPULogic {
 
     public void markForDeletion() {
         this.markedForDeletion = true;
+    }
+
+    private CraftingTickBudget createTickBudget() {
+        var coProcessors = Math.max(0, cpu.getCoProcessors());
+        var effectiveCoProcessors = Math.min(coProcessors, NEConfig.ecoCraftingEffectiveCoProcessorCap);
+        var scaledBonus = (int) Math.sqrt((double) effectiveCoProcessors);
+        var maxOperations = Math.max(1, NEConfig.ecoCraftingMaxOperationsPerTick);
+        var maxPatterns = Math.max(1, Math.min(Math.min(NEConfig.ecoCraftingMaxPatternsPerTick, 1 + scaledBonus), maxOperations));
+        var maxProviderChecks = Math.max(maxPatterns, NEConfig.ecoCraftingMaxProviderChecksPerTick);
+        return new CraftingTickBudget(
+            maxOperations,
+            maxPatterns,
+            maxProviderChecks,
+            System.nanoTime() + NEConfig.ecoCraftingTimeBudgetNanos,
+            effectiveCoProcessors);
+    }
+
+    private CraftingTickResult processTaskRange(
+        ExecutingCraftingJob job,
+        int startInclusive,
+        int endExclusive,
+        CraftingTickBudget budget,
+        CraftingService craftingService,
+        IEnergyService energyService,
+        Level level,
+        long currentTick
+    ) {
+        var pushedPatterns = 0;
+        var exhaustionReason = ExhaustionReason.NONE;
+        var iterator = job.tasks.entrySet().iterator();
+        for (int skipped = 0; skipped < startInclusive && iterator.hasNext(); skipped++) {
+            iterator.next();
+        }
+
+        var taskIndex = startInclusive;
+        while (iterator.hasNext() && taskIndex < endExclusive) {
+            if (!budget.canContinue()) {
+                exhaustionReason = budget.getExhaustionReason();
+                break;
+            }
+
+            var task = iterator.next();
+            var progress = task.getValue();
+            if (progress.value <= 0) {
+                iterator.remove();
+                continue;
+            }
+
+            var attempt = tryPushPattern(task, budget, craftingService, energyService, level, currentTick);
+            pushedPatterns += attempt.pushedPatterns;
+
+            if (progress.value <= 0) {
+                iterator.remove();
+            }
+
+            if (attempt.advanceTaskCursor) {
+                job.nextTaskIndex = progress.value > 0 ? taskIndex + 1 : taskIndex;
+            } else {
+                job.nextTaskIndex = taskIndex;
+            }
+
+            if (attempt.exhaustionReason != ExhaustionReason.NONE) {
+                exhaustionReason = attempt.exhaustionReason;
+                break;
+            }
+
+            taskIndex++;
+        }
+
+        return new CraftingTickResult(pushedPatterns, exhaustionReason);
+    }
+
+    private PatternPushAttempt tryPushPattern(
+        Map.Entry<IPatternDetails, ExecutingCraftingJob.TaskProgress> task,
+        CraftingTickBudget budget,
+        CraftingService craftingService,
+        IEnergyService energyService,
+        Level level,
+        long currentTick
+    ) {
+        if (!budget.tryConsumeOperation()) {
+            return PatternPushAttempt.exhausted(budget.getExhaustionReason());
+        }
+
+        var details = task.getKey();
+        var progress = task.getValue();
+        var expectedOutputs = new KeyCounter();
+        var expectedContainerItems = new KeyCounter();
+        @Nullable
+        var craftingContainer = CraftingCpuHelper.extractPatternInputs(
+            details, inventory, level, expectedOutputs, expectedContainerItems);
+
+        if (craftingContainer == null) {
+            progress.nextProviderIndex = 0;
+            return PatternPushAttempt.noProgress(true);
+        }
+
+        if (!budget.tryConsumePatternAttempt()) {
+            CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+            return PatternPushAttempt.exhausted(budget.getExhaustionReason());
+        }
+
+        var patternPower = CraftingCpuHelper.calculatePatternPower(craftingContainer);
+        budget.recordEnergySimulation();
+        if (energyService.extractAEPower(patternPower, Actionable.SIMULATE, PowerMultiplier.CONFIG)
+            < patternPower - POWER_EPSILON) {
+            job.lowPowerUntilTick = currentTick + LOW_POWER_BACKOFF_TICKS;
+            CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+            return new PatternPushAttempt(0, ExhaustionReason.LOW_POWER, false);
+        }
+
+        var remainingProviderChecks = budget.getRemainingProviderChecks();
+        if (remainingProviderChecks <= 0) {
+            CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+            return PatternPushAttempt.exhausted(budget.getExhaustionReason());
+        }
+
+        int enumeratedProviders = 0;
+        int deferredProviderCount = Math.min(Math.max(0, progress.nextProviderIndex), Math.max(0, remainingProviderChecks - 1));
+        var deferredProviders = new java.util.ArrayList<appeng.api.networking.crafting.ICraftingProvider>(
+            Math.min(deferredProviderCount, budget.getRemainingProviderChecks()));
+        boolean providerBudgetExhausted = false;
+        for (var provider : craftingService.getProviders(details)) {
+            if (!budget.tryConsumeProviderCheck()) {
+                providerBudgetExhausted = true;
+                break;
+            }
+
+            enumeratedProviders++;
+            if (deferredProviderCount > 0) {
+                deferredProviders.add(provider);
+                deferredProviderCount--;
+                continue;
+            }
+
+            if (provider == null || provider.isBusy()) {
+                continue;
+            }
+
+            if (provider.pushPattern(details, craftingContainer)) {
+                job.lowPowerUntilTick = 0;
+                // The provider has already accepted the pattern, so this path cannot roll the dispatch back.
+                // If actual extraction underflows after a successful simulation on the same server-thread tick,
+                // suspend further dispatch and surface it loudly instead of silently continuing free pushes.
+                var extractedPower = energyService.extractAEPower(patternPower, Actionable.MODULATE, PowerMultiplier.CONFIG);
+                if (extractedPower < patternPower - POWER_EPSILON) {
+                    LOGGER.error(
+                        "ECO crafting CPU at {} in {} accepted a pattern after power simulation, but actual extraction underflowed (required={}, extracted={}). Suspending further dispatch.",
+                        formatCpuPosition(),
+                        cpu.getLevel().dimension().location(),
+                        patternPower,
+                        extractedPower);
+                    job.suspended = true;
+                    job.lowPowerUntilTick = currentTick + LOW_POWER_BACKOFF_TICKS;
+                }
+                finishPatternPush(expectedOutputs, expectedContainerItems);
+                progress.value--;
+                progress.nextProviderIndex = enumeratedProviders;
+                cpu.markDirty();
+                return new PatternPushAttempt(1, ExhaustionReason.NONE, true);
+            }
+        }
+
+        if (enumeratedProviders == 0) {
+            CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+            return PatternPushAttempt.noProgress(true);
+        }
+
+        for (int deferredIndex = 0; deferredIndex < deferredProviders.size(); deferredIndex++) {
+            var provider = deferredProviders.get(deferredIndex);
+            if (provider == null || provider.isBusy()) {
+                continue;
+            }
+
+            if (provider.pushPattern(details, craftingContainer)) {
+                job.lowPowerUntilTick = 0;
+                var extractedPower = energyService.extractAEPower(patternPower, Actionable.MODULATE, PowerMultiplier.CONFIG);
+                if (extractedPower < patternPower - POWER_EPSILON) {
+                    LOGGER.error(
+                        "ECO crafting CPU at {} in {} accepted a pattern after power simulation, but actual extraction underflowed (required={}, extracted={}). Suspending further dispatch.",
+                        formatCpuPosition(),
+                        cpu.getLevel().dimension().location(),
+                        patternPower,
+                        extractedPower);
+                    job.suspended = true;
+                    job.lowPowerUntilTick = currentTick + LOW_POWER_BACKOFF_TICKS;
+                }
+                finishPatternPush(expectedOutputs, expectedContainerItems);
+                progress.value--;
+                progress.nextProviderIndex = normalizeIndex(deferredIndex + 1, enumeratedProviders);
+                cpu.markDirty();
+                return new PatternPushAttempt(1, ExhaustionReason.NONE, true);
+            }
+        }
+
+        if (providerBudgetExhausted) {
+            progress.nextProviderIndex = normalizeIndex(deferredProviders.size() + 1, enumeratedProviders);
+            CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+            return PatternPushAttempt.exhausted(budget.getExhaustionReason());
+        }
+
+        progress.nextProviderIndex = normalizeIndex(progress.nextProviderIndex + 1, enumeratedProviders);
+        CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
+        return PatternPushAttempt.noProgress(true);
+    }
+
+    private void finishPatternPush(KeyCounter expectedOutputs, KeyCounter expectedContainerItems) {
+        var job = this.job;
+        if (job == null) {
+            return;
+        }
+
+        for (var expectedOutput : expectedOutputs) {
+            job.waitingFor.insert(expectedOutput.getKey(), expectedOutput.getLongValue(), Actionable.MODULATE);
+        }
+        for (var expectedContainerItem : expectedContainerItems) {
+            job.waitingFor.insert(
+                expectedContainerItem.getKey(),
+                expectedContainerItem.getLongValue(),
+                Actionable.MODULATE);
+            job.timeTracker.addMaxItems(
+                expectedContainerItem.getLongValue(),
+                expectedContainerItem.getKey().getType());
+        }
+    }
+
+    private void handleTickResult(CraftingTickResult result, CraftingTickBudget budget, long currentTick) {
+        if (result.exhaustionReason == ExhaustionReason.NONE) {
+            consecutiveBudgetExhaustions = 0;
+            return;
+        }
+
+        if (result.exhaustionReason == ExhaustionReason.LOW_POWER) {
+            consecutiveBudgetExhaustions = 0;
+            if (NEConfig.ecoCraftingDebugProfiling) {
+                LOGGER.info(
+                    "ECO crafting CPU throttled for low power at {} in {} (queue={}, coProcessors={}, effectiveCoProcessors={}, providerChecks={}, energySimulations={})",
+                    formatCpuPosition(),
+                    cpu.getLevel().dimension().location(),
+                    job != null ? job.tasks.size() : 0,
+                    Math.max(0, cpu.getCoProcessors()),
+                    budget.effectiveCoProcessors,
+                    budget.providerChecks,
+                    budget.energySimulations);
+            }
+            return;
+        }
+
+        consecutiveBudgetExhaustions++;
+        if (NEConfig.ecoCraftingDebugProfiling) {
+            LOGGER.info(
+                "ECO crafting CPU deferred work at {} in {} (reason={}, queue={}, coProcessors={}, effectiveCoProcessors={}, pushedPatterns={}, operations={}, providerChecks={}, energySimulations={})",
+                formatCpuPosition(),
+                cpu.getLevel().dimension().location(),
+                result.exhaustionReason.name(),
+                job != null ? job.tasks.size() : 0,
+                Math.max(0, cpu.getCoProcessors()),
+                budget.effectiveCoProcessors,
+                result.pushedPatterns,
+                budget.operations,
+                budget.providerChecks,
+                budget.energySimulations);
+        }
+
+        if (consecutiveBudgetExhaustions >= BUDGET_WARNING_THRESHOLD
+            && currentTick - lastBudgetWarningTick >= BUDGET_WARNING_INTERVAL_TICKS) {
+            lastBudgetWarningTick = currentTick;
+            LOGGER.warn(
+                "ECO crafting CPU at {} in {} repeatedly hit per-tick limits (reason={}, queue={}, effectiveCoProcessors={}, providerChecks={}, pushedPatterns={}).",
+                formatCpuPosition(),
+                cpu.getLevel().dimension().location(),
+                result.exhaustionReason.name(),
+                job != null ? job.tasks.size() : 0,
+                budget.effectiveCoProcessors,
+                budget.providerChecks,
+                result.pushedPatterns);
+        }
+    }
+
+    private String formatCpuPosition() {
+        return cpu.getOwner() != null ? cpu.getOwner().getBlockPos().toShortString() : "<virtual>";
+    }
+
+    private static int normalizeIndex(int index, int size) {
+        if (size <= 0) {
+            return 0;
+        }
+        return Math.floorMod(index, size);
+    }
+
+    private enum ExhaustionReason {
+        NONE,
+        OPERATION_LIMIT,
+        PATTERN_LIMIT,
+        PROVIDER_CHECK_LIMIT,
+        TIME_LIMIT,
+        LOW_POWER
+    }
+
+    private static final class CraftingTickBudget {
+        private final int maxOperations;
+        private final int maxPatterns;
+        private final int maxProviderChecks;
+        private final long deadlineNanos;
+        private final int effectiveCoProcessors;
+        private int operations;
+        private int patternAttempts;
+        private int providerChecks;
+        private int energySimulations;
+
+        private CraftingTickBudget(
+            int maxOperations,
+            int maxPatterns,
+            int maxProviderChecks,
+            long deadlineNanos,
+            int effectiveCoProcessors
+        ) {
+            this.maxOperations = maxOperations;
+            this.maxPatterns = maxPatterns;
+            this.maxProviderChecks = maxProviderChecks;
+            this.deadlineNanos = deadlineNanos;
+            this.effectiveCoProcessors = effectiveCoProcessors;
+        }
+
+        private boolean canContinue() {
+            return getExhaustionReason() == ExhaustionReason.NONE;
+        }
+
+        private boolean tryConsumeOperation() {
+            if (getExhaustionReason() != ExhaustionReason.NONE || operations >= maxOperations) {
+                return false;
+            }
+            operations++;
+            return getExhaustionReason() == ExhaustionReason.NONE;
+        }
+
+        private boolean tryConsumePatternAttempt() {
+            if (getExhaustionReason() != ExhaustionReason.NONE || patternAttempts >= maxPatterns) {
+                return false;
+            }
+            patternAttempts++;
+            return getExhaustionReason() == ExhaustionReason.NONE;
+        }
+
+        private boolean tryConsumeProviderCheck() {
+            if (getExhaustionReason() != ExhaustionReason.NONE || providerChecks >= maxProviderChecks) {
+                return false;
+            }
+            providerChecks++;
+            return getExhaustionReason() == ExhaustionReason.NONE;
+        }
+
+        private int getRemainingProviderChecks() {
+            return Math.max(0, maxProviderChecks - providerChecks);
+        }
+
+        private void recordEnergySimulation() {
+            energySimulations++;
+        }
+
+        private ExhaustionReason getExhaustionReason() {
+            if (System.nanoTime() >= deadlineNanos) {
+                return ExhaustionReason.TIME_LIMIT;
+            }
+            if (operations >= maxOperations) {
+                return ExhaustionReason.OPERATION_LIMIT;
+            }
+            if (patternAttempts >= maxPatterns) {
+                return ExhaustionReason.PATTERN_LIMIT;
+            }
+            if (providerChecks >= maxProviderChecks) {
+                return ExhaustionReason.PROVIDER_CHECK_LIMIT;
+            }
+            return ExhaustionReason.NONE;
+        }
+    }
+
+    private record CraftingTickResult(int pushedPatterns, ExhaustionReason exhaustionReason) {
+        private CraftingTickResult merge(CraftingTickResult other) {
+            var mergedReason = this.exhaustionReason != ExhaustionReason.NONE ? this.exhaustionReason : other.exhaustionReason;
+            return new CraftingTickResult(this.pushedPatterns + other.pushedPatterns, mergedReason);
+        }
+    }
+
+    private record PatternPushAttempt(int pushedPatterns, ExhaustionReason exhaustionReason, boolean advanceTaskCursor) {
+        private static PatternPushAttempt exhausted(ExhaustionReason reason) {
+            return new PatternPushAttempt(0, reason, false);
+        }
+
+        private static PatternPushAttempt noProgress(boolean advanceTaskCursor) {
+            return new PatternPushAttempt(0, ExhaustionReason.NONE, advanceTaskCursor);
+        }
     }
 }

--- a/src/main/java/cn/dancingsnow/neoecoae/api/me/ECOCraftingCPULogic.java
+++ b/src/main/java/cn/dancingsnow/neoecoae/api/me/ECOCraftingCPULogic.java
@@ -163,9 +163,12 @@ public class ECOCraftingCPULogic {
     }
 
     /**
-     * Try to push patterns into available interfaces, i.e. do the actual crafting execution.
+     * Executes one bounded ECO crafting scheduling pass.
      *
-     * @return How many patterns were successfully pushed.
+     * <p>The scheduler resumes from the persisted task and provider cursors, and stops when the
+     * {@link CraftingTickBudget} is exhausted, power is insufficient, or no more progress can be made.</p>
+     *
+     * @return The number of pushed patterns and the reason scheduling stopped.
      */
     private CraftingTickResult executeCrafting(
         CraftingTickBudget budget, CraftingService craftingService, IEnergyService energyService, Level level, long currentTick) {
@@ -506,6 +509,9 @@ public class ECOCraftingCPULogic {
         var exhaustionReason = ExhaustionReason.NONE;
         var iterator = job.tasks.entrySet().iterator();
         for (int skipped = 0; skipped < startInclusive && iterator.hasNext(); skipped++) {
+            if (!budget.canContinue()) {
+                return new CraftingTickResult(pushedPatterns, budget.getExhaustionReason());
+            }
             iterator.next();
         }
 

--- a/src/main/java/cn/dancingsnow/neoecoae/api/me/ExecutingCraftingJob.java
+++ b/src/main/java/cn/dancingsnow/neoecoae/api/me/ExecutingCraftingJob.java
@@ -18,7 +18,7 @@
 
 package cn.dancingsnow.neoecoae.api.me;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jetbrains.annotations.Nullable;
@@ -49,17 +49,22 @@ public class ExecutingCraftingJob {
     private static final String NBT_REMAINING_AMOUNT = "remainingAmount";
     private static final String NBT_TASKS = "tasks";
     private static final String NBT_CRAFTING_PROGRESS = "#craftingProgress";
+    private static final String NBT_NEXT_TASK_INDEX = "nextTaskIndex";
+    private static final String NBT_LOW_POWER_UNTIL_TICK = "lowPowerUntilTick";
+    private static final String NBT_NEXT_PROVIDER_INDEX = "nextProviderIndex";
     private static final String NBT_SUSPENDED = "suspended";
 
     final CraftingLink link;
     final ListCraftingInventory waitingFor;
-    final Map<IPatternDetails, TaskProgress> tasks = new HashMap<>();
+    final Map<IPatternDetails, TaskProgress> tasks = new LinkedHashMap<>();
     final ElapsedTimeTracker timeTracker;
     GenericStack finalOutput;
     long remainingAmount;
     @Nullable
     Integer playerId;
     boolean suspended;
+    int nextTaskIndex;
+    long lowPowerUntilTick;
 
     @FunctionalInterface
     interface CraftingDifferenceListener {
@@ -88,6 +93,8 @@ public class ExecutingCraftingJob {
         this.link = link;
         this.playerId = playerId;
         this.suspended = false;
+        this.nextTaskIndex = 0;
+        this.lowPowerUntilTick = 0;
     }
 
     ExecutingCraftingJob(CompoundTag data, HolderLookup.Provider registries,
@@ -117,11 +124,16 @@ public class ExecutingCraftingJob {
             if (details != null) {
                 final TaskProgress tp = new TaskProgress();
                 tp.value = item.getLong(NBT_CRAFTING_PROGRESS);
+                if (item.contains(NBT_NEXT_PROVIDER_INDEX, Tag.TAG_INT)) {
+                    tp.nextProviderIndex = item.getInt(NBT_NEXT_PROVIDER_INDEX);
+                }
                 this.tasks.put(details, tp);
             }
         }
 
         this.suspended = data.getBoolean(NBT_SUSPENDED);
+        this.nextTaskIndex = data.getInt(NBT_NEXT_TASK_INDEX);
+        this.lowPowerUntilTick = data.getLong(NBT_LOW_POWER_UNTIL_TICK);
     }
 
     CompoundTag writeToNBT(HolderLookup.Provider registries) {
@@ -140,11 +152,14 @@ public class ExecutingCraftingJob {
         for (var e : this.tasks.entrySet()) {
             var item = e.getKey().getDefinition().toTag(registries);
             item.putLong(NBT_CRAFTING_PROGRESS, e.getValue().value);
+            item.putInt(NBT_NEXT_PROVIDER_INDEX, e.getValue().nextProviderIndex);
             list.add(item);
         }
         data.put(NBT_TASKS, list);
 
         data.putLong(NBT_REMAINING_AMOUNT, remainingAmount);
+        data.putInt(NBT_NEXT_TASK_INDEX, nextTaskIndex);
+        data.putLong(NBT_LOW_POWER_UNTIL_TICK, lowPowerUntilTick);
         if (this.playerId != null) {
             data.putInt(NBT_PLAYER_ID, this.playerId);
         }
@@ -155,5 +170,6 @@ public class ExecutingCraftingJob {
 
     static class TaskProgress {
         long value = 0;
+        int nextProviderIndex = 0;
     }
 }

--- a/src/main/java/cn/dancingsnow/neoecoae/blocks/entity/ECOIntegratedWorkingStationBlockEntity.java
+++ b/src/main/java/cn/dancingsnow/neoecoae/blocks/entity/ECOIntegratedWorkingStationBlockEntity.java
@@ -121,6 +121,7 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
     implements ISyncPersistRPCBlockEntity, IGridTickable, IUpgradeableObject, IConfigurableObject {
     private static final IGuiTexture AUTO_EXPORT_OFF = AETextures.icon(Icon.AUTO_EXPORT_OFF);
     private static final IGuiTexture AUTO_EXPORT_ON = AETextures.icon(Icon.AUTO_EXPORT_ON);
+    private static final long EXPORT_TARGET_CACHE_TTL_TICKS = 20;
 
     @Getter
     private final FieldManagedStorage syncStorage = new FieldManagedStorage(this);
@@ -218,6 +219,7 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
 
     @SuppressWarnings("UnstableApiUsage")
     private final HashMap<Direction, Map<AEKeyType, ExternalStorageStrategy>> exportStrategies = new HashMap<>();
+    private final HashMap<Direction, CachedExportTarget> exportTargets = new HashMap<>();
 
     @Getter
     @Setter
@@ -591,9 +593,19 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
 
     @SuppressWarnings("UnstableApiUsage")
     private @Nullable CompositeStorage getTarget(Direction dir) {
+        if (!(this.level instanceof ServerLevel serverLevel)) {
+            return null;
+        }
+
+        var gameTime = serverLevel.getGameTime();
+        var cached = this.exportTargets.get(dir);
+        if (cached != null && cached.expiresAtTick > gameTime) {
+            return cached.target;
+        }
+
         if (this.exportStrategies.get(dir) == null) {
             var be = this.getBlockEntity();
-            this.exportStrategies.put(dir, StackWorldBehaviors.createExternalStorageStrategies((ServerLevel) be.getLevel(), be.getBlockPos().relative(dir), dir.getOpposite()));
+            this.exportStrategies.put(dir, StackWorldBehaviors.createExternalStorageStrategies(serverLevel, be.getBlockPos().relative(dir), dir.getOpposite()));
         }
 
         var externalStorages = new IdentityHashMap<AEKeyType, MEStorage>(2);
@@ -605,10 +617,17 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
             }
         }
 
+        CompositeStorage target = null;
         if (!externalStorages.isEmpty()) {
-            return new CompositeStorage(externalStorages);
+            target = new CompositeStorage(externalStorages);
         }
-        return null;
+        this.exportTargets.put(dir, new CachedExportTarget(target, gameTime + EXPORT_TARGET_CACHE_TTL_TICKS));
+        return target;
+    }
+
+    private void invalidateExportCache(Direction dir) {
+        this.exportStrategies.remove(dir);
+        this.exportTargets.remove(dir);
     }
 
     @Override
@@ -991,11 +1010,7 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
                         allowOutputs.add(internalSide);
                     }
 
-                    // Clear cached strategy for this direction so it refreshes when re-enabled
-                    try {
-                        exportStrategies.remove(getOrientation().getSide(internalSide));
-                    } catch (Throwable ignored) {
-                    }
+                    invalidateExportCache(getOrientation().getSide(internalSide));
 
                     saveChanges();
                     markForUpdate();
@@ -1050,5 +1065,8 @@ public class ECOIntegratedWorkingStationBlockEntity extends AENetworkedPoweredBl
         grid.addChild(sideToggle.apply(RelativeSide.BACK, "gui.neoecoae.relative_side.back"));
 
         return window;
+    }
+
+    private record CachedExportTarget(@Nullable CompositeStorage target, long expiresAtTick) {
     }
 }

--- a/src/main/java/cn/dancingsnow/neoecoae/config/NEConfig.java
+++ b/src/main/java/cn/dancingsnow/neoecoae/config/NEConfig.java
@@ -43,6 +43,57 @@ public class NEConfig {
         BUILDER.pop();
     }
 
+    static {
+        BUILDER
+            .comment(
+                "ECO crafting CPU scheduler limits.",
+                "These caps keep large crafting jobs from monopolizing a single server tick."
+            )
+            .push("ecoCrafting");
+    }
+
+    private static final ModConfigSpec.IntValue ECO_CRAFTING_MAX_OPERATIONS_PER_TICK = BUILDER
+        .comment(
+            "Maximum number of ECO crafting scheduler operations allowed per tick.",
+            "Lower values reduce worst-case tick time, higher values may improve throughput."
+        )
+        .defineInRange("maxOperationsPerTick", 32, 1, 4096);
+
+    private static final ModConfigSpec.IntValue ECO_CRAFTING_MAX_PATTERNS_PER_TICK = BUILDER
+        .comment(
+            "Maximum number of crafting patterns an ECO CPU may dispatch in a single tick.",
+            "Co-processors still improve throughput, but never beyond this cap."
+        )
+        .defineInRange("maxPatternsPerTick", 8, 1, 512);
+
+    private static final ModConfigSpec.IntValue ECO_CRAFTING_MAX_PROVIDER_CHECKS_PER_TICK = BUILDER
+        .comment(
+            "Maximum provider checks an ECO CPU may perform in a single tick.",
+            "This bounds provider scans when many pattern providers are present."
+        )
+        .defineInRange("maxProviderChecksPerTick", 64, 1, 4096);
+
+    private static final ModConfigSpec.LongValue ECO_CRAFTING_TIME_BUDGET_NANOS = BUILDER
+        .comment(
+            "Approximate per-tick wall-clock budget for ECO crafting scheduling in nanoseconds.",
+            "Once exceeded, remaining work is deferred to the next tick."
+        )
+        .defineInRange("timeBudgetNanos", 2_000_000L, 100_000L, 50_000_000L);
+
+    private static final ModConfigSpec.IntValue ECO_CRAFTING_EFFECTIVE_COPROCESSOR_CAP = BUILDER
+        .comment(
+            "Maximum co-processors counted by the bounded ECO crafting scheduler.",
+            "Raw co-processor count is clamped before throughput scaling is calculated."
+        )
+        .defineInRange("effectiveCoProcessorCap", 256, 1, 65_536);
+
+    private static final ModConfigSpec.BooleanValue ECO_CRAFTING_DEBUG_PROFILING = BUILDER
+        .comment(
+            "Enable extra ECO crafting scheduler diagnostics in the log.",
+            "Disabled by default to avoid log spam on production servers."
+        )
+        .define("debugProfiling", false);
+
     private static final ModConfigSpec.BooleanValue POST_CRAFTING_EVENT = BUILDER
         .comment(
             "Post a vanilla crafting event (ItemCraftedEvent) when the Crafting System finishes a recipe.",
@@ -50,11 +101,21 @@ public class NEConfig {
         )
         .define("postCraftingEvent", false);
 
+    static {
+        BUILDER.pop();
+    }
+
     public static final ModConfigSpec SPEC = BUILDER.build();
 
     public static int craftingSystemMaxLength;
     public static int computationSystemMaxLength;
     public static int storageSystemMaxLength;
+    public static int ecoCraftingMaxOperationsPerTick;
+    public static int ecoCraftingMaxPatternsPerTick;
+    public static int ecoCraftingMaxProviderChecksPerTick;
+    public static long ecoCraftingTimeBudgetNanos;
+    public static int ecoCraftingEffectiveCoProcessorCap;
+    public static boolean ecoCraftingDebugProfiling;
     public static boolean postCraftingEvent;
 
     @SubscribeEvent
@@ -62,6 +123,12 @@ public class NEConfig {
         craftingSystemMaxLength = CRAFTING_SYSTEM_MAX_LENGTH.get();
         computationSystemMaxLength = COMPUTATION_SYSTEM_MAX_LENGTH.get();
         storageSystemMaxLength = STORAGE_SYSTEM_MAX_LENGTH.get();
+        ecoCraftingMaxOperationsPerTick = ECO_CRAFTING_MAX_OPERATIONS_PER_TICK.get();
+        ecoCraftingMaxPatternsPerTick = ECO_CRAFTING_MAX_PATTERNS_PER_TICK.get();
+        ecoCraftingMaxProviderChecksPerTick = ECO_CRAFTING_MAX_PROVIDER_CHECKS_PER_TICK.get();
+        ecoCraftingTimeBudgetNanos = ECO_CRAFTING_TIME_BUDGET_NANOS.get();
+        ecoCraftingEffectiveCoProcessorCap = ECO_CRAFTING_EFFECTIVE_COPROCESSOR_CAP.get();
+        ecoCraftingDebugProfiling = ECO_CRAFTING_DEBUG_PROFILING.get();
         postCraftingEvent = POST_CRAFTING_EVENT.get();
     }
 }


### PR DESCRIPTION
## 背景

本 PR 修复一个 ECO 合成 CPU 在极端合成场景下可能触发服务器 Watchdog 的问题。

已观察到的崩溃路径位于 `ECOCraftingCPULogic.executeCrafting` 附近，热点主要来自在单个 server tick 内直接按照 `cpu.getCoProcessors() + 1` 推进大量合成任务，并在 provider 遍历过程中反复调用 `energyService.extractAEPower(..., SIMULATE)`。

当 ECO CPU 协处理器数量很大、可用 provider 很多、材料充足时，原逻辑可能在一个 tick 内执行大量 provider 扫描、样板推送尝试和能量模拟检查，导致单 tick 超过 Watchdog 阈值并强制终止服务器。

这不是传统意义上的死循环或死锁，而是单 tick 工作量无界增长导致的服务器线程长时间 RUNNABLE 执行。

## 主要修复内容

- 将 ECO 合成 CPU 从原来的 `coProcessors + 1` 同 tick 直接推送模型，改为有界的 per-tick scheduler。
- 新增每 tick 调度预算：
  - `maxOperationsPerTick`
  - `maxPatternsPerTick`
  - `maxProviderChecksPerTick`
  - `timeBudgetNanos`
  - `effectiveCoProcessorCap`
- 协处理器仍然提升吞吐，但现在使用 capped / sqrt 风格的次线性缩放，避免原始协处理器数量直接放大单 tick 工作量。
- 新增 task cursor 和 provider cursor，使大合成任务可以跨多个 tick 平滑推进。
- provider 枚举本身也纳入 `maxProviderChecksPerTick` 预算，避免先无界收集全部 provider 再应用预算。
- provider cursor 改为 bounded rotating window，避免 `nextProviderIndex` 在大量 provider 场景下无界增长或整 tick 只用于跳过 provider。
- 将能量模拟从“每个 provider 尝试一次”减少为“每个 pattern attempt 一次”。
- 低电量时会进入短暂 backoff，避免在无电状态下继续高频扫描 provider。
- `MODULATE` 实际扣能量结果现在会被检查；如果在同 tick 成功模拟并且 provider 已接受 pattern 后实际扣能量不足，会记录严重错误并暂停进一步 dispatch，避免静默继续产生免费推送。
- 新增 `ecoCrafting` 服务端配置项，并补充配置注释。
- `ExecutingCraftingJob` 新增调度状态持久化字段，用于保存 task/provider cursor 和低电 backoff 状态。
- 对集成工作站自动输出路径增加一个小型 target cache，减少每 tick 重复构建外部存储 wrapper。
- 增加 JDK 21 构建说明和辅助脚本，避免使用 JDK 25 运行 Gradle 8.12.1。

## 构建环境修复

本项目当前使用 Gradle 8.12.1。此前本地环境中 Gradle 被 JDK 25.0.3 启动，同时 PATH 上的 `java` 又指向 Java 8，容易导致构建环境混乱。

本 PR 中：

- 新增 `BUILDING.md`，说明该项目在 Gradle 8.12.1 下应使用 JDK 21。
- 新增：
  - `scripts/use-jdk21.ps1`
  - `scripts/use-jdk21.sh`
- 在 `build.gradle` 中增加 fail-fast 检查：当 Gradle 8.12.1 被 Java 25+ 启动时，给出明确错误提示。
- 没有将本机绝对 `JAVA_HOME` 路径写入 `gradle.properties`。

## 新增配置

新增 `ecoCrafting` 配置组：

```properties
ecoCrafting.maxOperationsPerTick = 32
ecoCrafting.maxPatternsPerTick = 8
ecoCrafting.maxProviderChecksPerTick = 64
ecoCrafting.timeBudgetNanos = 2000000
ecoCrafting.effectiveCoProcessorCap = 256
ecoCrafting.debugProfiling = false
```

## 验证结果

已在 JDK 21 + Gradle 8.12.1 环境下完成以下验证：

- `java -version`：Gradle 启动与命令行 Java 均为 JDK 21
- `./gradlew.bat --version`：Launcher JVM 为 JDK 21
- `./gradlew.bat compileJava --no-daemon --console=plain`：通过
- `./gradlew.bat jar --no-daemon --console=plain`：通过

本次修复的目标是确保 ECO 合成 CPU 在极端负载下仍然保持单 tick 工作量有界，并让大型合成任务分摊到多个 tick 中推进，而不是在一个 tick 内无界膨胀。

## 已知无关问题

当前 `:test` 任务仍存在一个**与本 PR 无关的预存问题**：

- `DefaultTestTaskReports`
- `DefaultReportContainer`
- `Type T not present`

该问题表现为 Gradle 在实例化 `:test` 任务阶段失败。

本 PR **没有静默禁用测试任务**，也**没有**把这个问题当作 ECO Watchdog 修复的一部分处理，因为它并未阻塞 `compileJava` 或 `jar` 的验证。
